### PR TITLE
feat: agregar detalle editable de foto

### DIFF
--- a/.src/core/ports/PhotoRepositoryPort.class
+++ b/.src/core/ports/PhotoRepositoryPort.class
@@ -14,6 +14,10 @@ Public Function FindWithFilters(oSpec As PhotoSpecification, sortBy As String, s
   Error.Raise("PhotoRepositoryPort.FindWithFilters not implemented" & oSpec & sortBy & sortOrder & limit & offset)
 End
 
+Public Function FindPhotoById(iId As Integer) As PhotoEntity '' Retrieves a single photo entity by identifier with its persisted detail fields.
+  Error.Raise("PhotoRepositoryPort.FindPhotoById not implemented" & iId)
+End
+
 Public Function CountWithFilters(oSpec As PhotoSpecification) As Integer '' Returns the total count of photos matching the specification.
   Error.Raise("PhotoRepositoryPort.CountWithFilters not implemented" & oSpec)
 End
@@ -90,8 +94,16 @@ Public Function FindAlbums(Optional text As String, Optional id As Integer = 0, 
   Error.Raise("PhotoRepositoryPort.FindAlbums not implemented" & text & id & useSoftDelete)
 End
 
+Public Function FindAlbumsByPhoto(iPhotoId As Integer) As AlbumEntity[] '' Retrieves albums associated to a specific photo.
+  Error.Raise("PhotoRepositoryPort.FindAlbumsByPhoto not implemented" & iPhotoId)
+End
+
 Public Function FindTags(Optional text As String, Optional id As Integer = 0) As TagEntity[] '' Retrieves tag records with optional filters.
   Error.Raise("PhotoRepositoryPort.FindTags not implemented" & text & id)
+End
+
+Public Function FindTagsByPhoto(iPhotoId As Integer) As TagEntity[] '' Retrieves tags associated to a specific photo.
+  Error.Raise("PhotoRepositoryPort.FindTagsByPhoto not implemented" & iPhotoId)
 End
 
 Public Function GetAvailableDates() As String[] '' Returns a list of unique photo creation dates (YYYY-MM-DD).

--- a/.src/core/services/AlbumService.class
+++ b/.src/core/services/AlbumService.class
@@ -26,6 +26,14 @@ Public Function FindAlbums(Optional sText As String, Optional iId As Integer = 0
   
 End
 
+Public Function FindAlbumsByPhoto(iPhotoId As Integer) As AlbumEntity[] '' Retrieves albums associated to a photo.
+  
+  If iPhotoId <= 0 Then Return New AlbumEntity[]
+  
+  Return $PhotoRepository.FindAlbumsByPhoto(iPhotoId)
+  
+End
+
 Public Function AddAlbum(sName As String, sDescription As String) As Boolean ''Method to add a new album
   
   Dim oAlbum As New AlbumEntity

--- a/.src/core/services/PhotoService.class
+++ b/.src/core/services/PhotoService.class
@@ -69,6 +69,23 @@ Public Function LoadNextPage() As PhotoEntity[] '' Returns the next batch of pho
   
 End
 
+Public Function FindPhotoById(iId As Integer) As PhotoEntity '' Retrieves a single photo with persisted detail fields.
+  
+  If iId <= 0 Then Return Null
+  
+  Return $PhotoRepository.FindPhotoById(iId)
+  
+End
+
+Public Function UpdatePhoto(oPhoto As PhotoEntity) As Boolean '' Persists editable photo fields.
+  
+  If oPhoto = Null Then Return False
+  If oPhoto.Id <= 0 Then Return False
+  
+  Return $PhotoRepository.UpdatePhoto(oPhoto)
+  
+End
+
 Public Sub ApplyFilters(oSpec As PhotoSpecification) '' Applies the specified filters to the photo collection.
   
   $Iterator.SetSpecification(oSpec)

--- a/.src/core/services/QuestionInteractionService.class
+++ b/.src/core/services/QuestionInteractionService.class
@@ -3,11 +3,11 @@
 ' QuestionInteractionService.class
 
 Private $Logger As LoggerPort
-' Private $ShouldNotShowAgain As Boolean = False
+Private $ShouldNotShowAgain As Boolean = False
 Private $Titulo As String = "QuestionInteractionService"
 Private $LogMessage As LogMessage
 
-' Property ShouldNotShowAgain As Boolean
+Property ShouldNotShowAgain As Boolean
 
 Public Sub _new(oLogger As LoggerPort)
   
@@ -51,10 +51,10 @@ Public Sub SaveUserDecision(oConfiguration As Configuration, sConfigKey As Strin
   
 End
 
-' Private Function ShouldNotShowAgain_Read() As Boolean
-'   Return $ShouldNotShowAgain
-' End
+Private Function ShouldNotShowAgain_Read() As Boolean
+  Return $ShouldNotShowAgain
+End
 
-' Private Sub ShouldNotShowAgain_Write(Value As Boolean)
-'   $ShouldNotShowAgain = Value
-' End
+Private Sub ShouldNotShowAgain_Write(bShouldNotShowAgain As Boolean)
+  $ShouldNotShowAgain = bShouldNotShowAgain
+End

--- a/.src/core/services/TagService.class
+++ b/.src/core/services/TagService.class
@@ -23,6 +23,14 @@ Public Function FindTags(Optional sText As String, Optional iId As Integer = 0) 
 
 End
 
+Public Function FindTagsByPhoto(iPhotoId As Integer) As TagEntity[] '' Retrieves tags associated to a photo.
+
+  If iPhotoId <= 0 Then Return New TagEntity[]
+
+  Return $PhotoRepository.FindTagsByPhoto(iPhotoId)
+
+End
+
 Public Function AddTag(sName As String, sDescription As String, sColor As String) As Boolean '' Creates a new tag from primitive values.
 
   Dim oTag As New TagEntity

--- a/.src/infrastructure/data/SQLiteRepositoryAdapter.class
+++ b/.src/infrastructure/data/SQLiteRepositoryAdapter.class
@@ -119,6 +119,28 @@ Catch
   
 End
 
+Public Function FindPhotoById(iId As Integer) As PhotoEntity '' Retrieves a single photo with all persisted detail fields.
+  
+  Dim oResult As Result
+  Dim aPhotos As PhotoEntity[]
+  
+  If iId <= 0 Then Return Null
+  
+  oResult = $DbContext.DBConnection.Exec("SELECT * FROM " & SQLiteRepositoryAdapter.TABLE_PHOTOS & " WHERE photo_id = &1 LIMIT 1", iId)
+  If Not oResult.Available Then Return Null
+  
+  aPhotos = MapResultToEntities(oResult)
+  If aPhotos.Count = 0 Then Return Null
+  
+  Return aPhotos[0]
+  
+Catch
+  $LogMessage = New LogMessage($Titulo, "FindPhotoById", "Problem retrieving photo detail: " & Error.Text)
+  $Logger.Error($LogMessage)
+  Return Null
+  
+End
+
 Public Function CountWithFilters(oSpec As PhotoSpecification) As Integer '' Count records in the photos table
   
   Dim oResult As Result
@@ -492,6 +514,16 @@ Public Function FindAlbums(Optional sText As String, Optional iId As Integer = 0
   Return MapAlbumEntitys($DbContext.DBConnection.Exec(sQuery))
 End
 
+Public Function FindAlbumsByPhoto(iPhotoId As Integer) As AlbumEntity[] '' Retrieves albums linked to the specified photo.
+  Dim sQuery As String
+  
+  If iPhotoId <= 0 Then Return New AlbumEntity[]
+  
+  sQuery = "SELECT a.*, COUNT(pa2.photo_id) AS photo_count FROM " & SQLiteRepositoryAdapter.TABLE_ALBUMS & " AS a " & "INNER JOIN " & SQLiteRepositoryAdapter.TABLE_PHOTOS_ALBUMS & " AS pa ON pa.album_id = a.album_id " & "LEFT JOIN " & SQLiteRepositoryAdapter.TABLE_PHOTOS_ALBUMS & " AS pa2 ON pa2.album_id = a.album_id " & "WHERE pa.photo_id = " & $DbContext.DBConnection.Quote(iPhotoId) & " AND a.soft_delete = 0 GROUP BY a.album_id ORDER BY LOWER(a.name)"
+  
+  Return MapAlbumEntitys($DbContext.DBConnection.Exec(sQuery))
+End
+
 Public Function FindTags(Optional sText As String, Optional iId As Integer = 0) As TagEntity[] '' Retrieves tags.
   Dim sQuery As String = "SELECT t.*, COUNT(pt.photo_id) AS photo_count FROM " & SQLiteRepositoryAdapter.TABLE_TAGS & " AS t LEFT JOIN " & SQLiteRepositoryAdapter.TABLE_PHOTOS_TAGS & " AS pt ON pt.tag_id = t.tag_id"
   Dim sCon As String = " WHERE "
@@ -501,6 +533,16 @@ Public Function FindTags(Optional sText As String, Optional iId As Integer = 0) 
   Endif
   If sText <> "" Then sQuery &= sCon & " LOWER(t.name) LIKE " & $DbContext.DBConnection.Quote("%" & Lower(sText) & "%")
   sQuery &= " GROUP BY t.tag_id ORDER BY LOWER(t.name)"
+  Return MapTagEntitys($DbContext.DBConnection.Exec(sQuery))
+End
+
+Public Function FindTagsByPhoto(iPhotoId As Integer) As TagEntity[] '' Retrieves tags linked to the specified photo.
+  Dim sQuery As String
+  
+  If iPhotoId <= 0 Then Return New TagEntity[]
+  
+  sQuery = "SELECT t.*, COUNT(pt2.photo_id) AS photo_count FROM " & SQLiteRepositoryAdapter.TABLE_TAGS & " AS t " & "INNER JOIN " & SQLiteRepositoryAdapter.TABLE_PHOTOS_TAGS & " AS pt ON pt.tag_id = t.tag_id " & "LEFT JOIN " & SQLiteRepositoryAdapter.TABLE_PHOTOS_TAGS & " AS pt2 ON pt2.tag_id = t.tag_id " & "WHERE pt.photo_id = " & $DbContext.DBConnection.Quote(iPhotoId) & " GROUP BY t.tag_id ORDER BY LOWER(t.name)"
+  
   Return MapTagEntitys($DbContext.DBConnection.Exec(sQuery))
 End
 
@@ -611,7 +653,12 @@ Private Function MapResultToEntities(oResult As Result) As PhotoEntity[]
     cPhoto.Hash256 = oResult["Hash256"]
     cPhoto.Thumbnail = oResult["thumbnail"]
     cPhoto.IsSoftDeleted = oResult["soft_delete"]
+    cPhoto.SoftDeleteDate = oResult["soft_deleted_date"]
+    cPhoto.SoftDeleteBy = oResult["soft_deleted_by"]
     cPhoto.IsLocked = oResult["is_locked"]
+    cPhoto.LockedBy = oResult["locked_by"]
+    cPhoto.LockedDate = oResult["locked_date"]
+    cPhoto.LockedReason = oResult["lock_reason"]
     oPhotos.Add(cPhoto)
   Next
   Return oPhotos
@@ -624,6 +671,7 @@ Private Sub MapAlbumEntitys(oResult As Result) As AlbumEntity[]
     cAlbum = New AlbumEntity
     cAlbum.Id = oResult["album_id"]
     cAlbum.Name = oResult["name"]
+    cAlbum.Description = oResult["description"]
     cAlbum.IsSoftDeleted = oResult["soft_delete"]
     cAlbum.PhotoCount = oResult["photo_count"]
     oAlbums.Add(cAlbum)

--- a/.src/views/FMain.class
+++ b/.src/views/FMain.class
@@ -669,7 +669,7 @@ Private Sub CreatePhotoPanels(aPhotos As PhotoEntity[])
   $Logger.Info($LogMessage)
   
   For Each cPhoto As PhotoEntity In aPhotos
-    oFPhoto = New FPhoto($PhotoSelectionService, cPhoto, $IsViewingTrash, PanelGalleryContent)
+    oFPhoto = New FPhoto($PhotoSelectionService, cPhoto, $IsViewingTrash, $PhotoService, $AlbumService, $TagService, $Logger, PanelGalleryContent)
     For i = 1 To $Amplifier
       oFPhoto.ResizeScaledForm(1)
     Next

--- a/.src/views/FPhoto.class
+++ b/.src/views/FPhoto.class
@@ -5,17 +5,25 @@ Private $PhotoId As Integer
 Private $SelectionService As PhotoSelectionService
 Private $PhotoEntity As PhotoEntity
 Private $IsTrashView As Boolean
+Private $PhotoService As PhotoService
+Private $AlbumService As AlbumService
+Private $TagService As TagService
+Private $Logger As LoggerPort
 
 Property Read PhotoId As Integer
 Property Read IsSelected As Boolean
 Property Read PhotoEntity As PhotoEntity
 
-Public Sub _new(oSelectionService As PhotoSelectionService, oPhoto As PhotoEntity, bIsTrashView As Boolean) '' Initializes the photo component with its entity and selection service.
+Public Sub _new(oSelectionService As PhotoSelectionService, oPhoto As PhotoEntity, bIsTrashView As Boolean, oPhotoService As PhotoService, oAlbumService As AlbumService, oTagService As TagService, oLogger As LoggerPort) '' Initializes the photo component with its entity and selection service.
   
   $SelectionService = oSelectionService
   $PhotoEntity = oPhoto
   $PhotoId = oPhoto.Id
   $IsTrashView = bIsTrashView
+  $PhotoService = oPhotoService
+  $AlbumService = oAlbumService
+  $TagService = oTagService
+  $Logger = oLogger
   
   Me.Width = 160
   Me.Height = 100
@@ -44,6 +52,7 @@ Public Sub _new(oSelectionService As PhotoSelectionService, oPhoto As PhotoEntit
   PictureBoxPhoto.Padding = 8
   
   If oPhoto.IsLocked Then ButtonLock.Picture = Picture["icon:/16/lock"]
+  UpdateTooltip()
   
 End
 
@@ -58,7 +67,10 @@ Public Sub Form_Enter() '' Handles mouse hover entry.
     ButtonDelete.Visible = True
     ButtonDelete.Raise()
     ButtonLock.Visible = False
+    ButtonDetails.Visible = False
   Else
+    ButtonDetails.Visible = True
+    ButtonDetails.Raise()
     ButtonLock.Visible = True
     ButtonLock.Raise()
     ButtonDelete.Visible = False
@@ -71,6 +83,7 @@ Public Sub Form_Leave() '' Handles mouse hover exit.
   ButtonSeleccionar.Visible = False
   PictureBoxPhoto.Border = Border.None
   
+  ButtonDetails.Visible = False
   ButtonLock.Visible = False
   ButtonDelete.Visible = False
 
@@ -144,6 +157,16 @@ Public Sub ButtonLock_Click()
   
 End
 
+Public Sub ButtonDetails_Click()
+
+  Dim oDialog As FPhotoDetails
+
+  oDialog = New FPhotoDetails($PhotoEntity, $PhotoService, $AlbumService, $TagService, $Logger)
+  oDialog.ShowModal()
+  RefreshTileVisuals()
+
+End
+
 
 ' =============================================================================
 '
@@ -179,3 +202,49 @@ Private Sub RefreshSelectionVisual()
   
 End
 
+Private Sub RefreshTileVisuals()
+  
+  Dim oUpdatedPhoto As PhotoEntity
+  
+  If $PhotoService = Null Then Return
+  
+  oUpdatedPhoto = $PhotoService.FindPhotoById($PhotoEntity.Id)
+  If oUpdatedPhoto = Null Then Return
+  
+  $PhotoEntity = oUpdatedPhoto
+  
+  If oUpdatedPhoto.IsLocked Then
+    ButtonLock.Picture = Picture["icon:/16/lock"]
+  Else
+    ButtonLock.Picture = Picture["icon:/16/unlock"]
+  Endif
+  
+  UpdateTooltip()
+  
+End
+
+Private Sub UpdateTooltip()
+  
+  Dim sTooltip As String
+  Dim sDescription As String
+  
+  sTooltip = $PhotoEntity.FileName
+  sDescription = BuildTooltipDescription($PhotoEntity.Description)
+  If sDescription <> "" Then sTooltip &= gb.NewLine & sDescription
+  
+  Me.Tooltip = sTooltip
+  PictureBoxPhoto.Tooltip = sTooltip
+  PanelPhoto.Tooltip = sTooltip
+  
+End
+
+Private Function BuildTooltipDescription(sDescription As String) As String
+  
+  If sDescription = Null Then sDescription = ""
+  sDescription = Trim(Replace(Replace(sDescription, gb.NewLine, " "), gb.Tab, " "))
+  If sDescription = "" Then Return ""
+  If Len(sDescription) > 120 Then sDescription = Left(sDescription, 117) & "..."
+  
+  Return ("Comment: ") & sDescription
+  
+End

--- a/.src/views/FPhoto.form
+++ b/.src/views/FPhoto.form
@@ -28,4 +28,9 @@
     Visible = False
     Picture = Picture["icon:/16/remove"]
   }
+  { ButtonDetails Button
+    MoveScaled(25,1,3.4286,3.4286)
+    Visible = False
+    Picture = Picture["icon:/16/more-h"]
+  }
 }

--- a/.src/views/FPhotoDetails.class
+++ b/.src/views/FPhotoDetails.class
@@ -1,2 +1,581 @@
 ' Gambas class file
 
+Private $OriginalPhoto As PhotoEntity
+Private $PhotoDetail As PhotoEntity
+Private $PhotoService As PhotoService
+Private $AlbumService As AlbumService
+Private $TagService As TagService
+Private $Logger As LoggerPort
+Private $IsBindingDescription As Boolean
+Private $CurrentAlbums As AlbumEntity[]
+Private $CurrentTags As TagEntity[]
+Private $OriginalAlbumIds As Integer[]
+Private $OriginalTagIds As Integer[]
+
+Public Sub _new(oPhoto As PhotoEntity, oPhotoService As PhotoService, oAlbumService As AlbumService, oTagService As TagService, oLogger As LoggerPort)
+  
+  $OriginalPhoto = oPhoto
+  $PhotoService = oPhotoService
+  $AlbumService = oAlbumService
+  $TagService = oTagService
+  $Logger = oLogger
+  
+End
+
+Public Sub Form_Open()
+  
+  InitializeTables()
+  ReloadDetails()
+  
+End
+
+Public Sub ButtonAccept_Click()
+
+  SaveChanges()
+
+End
+
+Public Sub ButtonExit_Click()
+
+  If Not ConfirmCloseIfPendingChanges() Then Return
+  Me.Close()
+
+End
+
+Public Sub ButtonAddAlbum_Click()
+  
+  Dim oDialog As FAlbumSelection
+  Dim oSelection As AlbumSelectionService
+  
+  If $PhotoDetail = Null Then Return
+  
+  oSelection = New AlbumSelectionService
+  oDialog = New FAlbumSelection($AlbumService, $Logger, oSelection, Enumeration.ALBUM_ADD_ACTION, Null, False)
+  If oDialog.ShowModal() <> Enumeration.DLG_OK Then Return
+  
+  For Each oAlbum As AlbumEntity In oSelection.GetSelectedAlbumEntities()
+    AddAlbumToCurrentList(oAlbum)
+  Next
+  
+  BindAlbums($CurrentAlbums)
+  UpdateSaveButtonState()
+  
+End
+
+Public Sub ButtonRemoveAlbum_Click()
+  
+  If $PhotoDetail = Null Then Return
+  If $CurrentAlbums = Null Then Return
+  
+  If RemoveSelectedAlbums() Then
+    BindAlbums($CurrentAlbums)
+    UpdateSaveButtonState()
+  Else
+    Message.Warning(("You must select at least one album"))
+  Endif
+  
+End
+
+Public Sub ButtonAddTag_Click()
+  
+  Dim oDialog As FTagSelection
+  Dim oSelection As TagSelectionService
+  Dim aSelectedTagIds As Integer[]
+  
+  If $PhotoDetail = Null Then Return
+  
+  oSelection = New TagSelectionService
+  oDialog = New FTagSelection($TagService, $Logger, oSelection, Enumeration.TAG_ADD_ACTION)
+  If oDialog.ShowModal() <> Enumeration.DLG_OK Then Return
+  
+  aSelectedTagIds = oSelection.GetSelectedIds()
+  AddTagsToCurrentList(aSelectedTagIds)
+  BindTags($CurrentTags)
+  UpdateSaveButtonState()
+  
+End
+
+Public Sub ButtonRemoveTag_Click()
+  
+  If $PhotoDetail = Null Then Return
+  If $CurrentTags = Null Then Return
+  
+  If RemoveSelectedTags() Then
+    BindTags($CurrentTags)
+    UpdateSaveButtonState()
+  Else
+    Message.Warning(("You must select at least one tag"))
+  Endif
+  
+End
+
+' =============================================================================
+'
+'          Private methods
+'
+' =============================================================================
+
+Private Sub InitializeTables()
+  
+  With TableViewAlbums
+    .Columns.Count = 2
+    .Rows.Count = 0
+    .Header = GridView.Horizontal
+    .Columns[0].Text = ("Album")
+    .Columns[0].Expand = True
+    .Columns[1].Text = ("Photos")
+    .Columns[1].Alignment = Align.Right
+    .Columns[1].Width = 55
+  End With
+  
+  With TableViewTags
+    .Columns.Count = 3
+    .Rows.Count = 0
+    .Header = GridView.Horizontal
+    .Columns[0].Text = ("Tag")
+    .Columns[0].Expand = True
+    .Columns[1].Text = ("Color")
+    .Columns[1].Width = 70
+    .Columns[2].Text = ("Photos")
+    .Columns[2].Alignment = Align.Right
+    .Columns[2].Width = 55
+  End With
+  
+End
+
+Private Sub ReloadDetails()
+  
+  Dim oPhoto As PhotoEntity
+  Dim aAlbums As AlbumEntity[]
+  Dim aTags As TagEntity[]
+  
+  If $OriginalPhoto = Null Then
+    Message.Error(("No photo selected"))
+    Me.Close()
+    Return
+  Endif
+  
+  oPhoto = LoadPhotoDetail()
+  If oPhoto = Null Then
+    Message.Error(("Could not load photo details"))
+    Return
+  Endif
+  
+  aAlbums = $AlbumService.FindAlbumsByPhoto(oPhoto.Id)
+  aTags = $TagService.FindTagsByPhoto(oPhoto.Id)
+  
+  $PhotoDetail = oPhoto
+  $CurrentAlbums = CloneAlbums(aAlbums)
+  $CurrentTags = CloneTags(aTags)
+  $OriginalAlbumIds = ExtractAlbumIds(aAlbums)
+  $OriginalTagIds = ExtractTagIds(aTags)
+  
+  BindPhoto(oPhoto)
+  BindAlbums($CurrentAlbums)
+  BindTags($CurrentTags)
+  SyncOriginalPhoto(oPhoto)
+  
+End
+
+Private Function LoadPhotoDetail() As PhotoEntity
+  
+  If $PhotoService = Null Then Return $OriginalPhoto
+  
+  Return $PhotoService.FindPhotoById($OriginalPhoto.Id)
+  
+End
+
+Private Sub BindPhoto(oPhoto As PhotoEntity)
+  
+  Me.Text = ("Photo details") & " - " & oPhoto.FileName
+  TextBoxName.Text = oPhoto.FileName
+  $IsBindingDescription = True
+  TextAreaDescription.Text = NzText(oPhoto.Description)
+  $IsBindingDescription = False
+  ValueBoxImportDate.Value = oPhoto.ImportDate
+  TextBoxImportUser.Text = NzText(oPhoto.ImportUser)
+  LabelStarsValue.Text = BuildStars(oPhoto.Stars)
+  
+  SwitchButtonLock.Value = oPhoto.IsLocked
+  TextBoxLockedBy.Text = NzText(oPhoto.LockedBy)
+  ValueBoxLockedDate.Value = oPhoto.LockedDate
+  TextAreaLockReason.Text = NzText(oPhoto.LockedReason)
+  
+  SwitchButtonTrash.Value = oPhoto.IsSoftDeleted
+  TextBoxSoftDeleteBy.Text = NzText(oPhoto.SoftDeleteBy)
+  ValueBoxSoftDeleteDate.Value = oPhoto.SoftDeleteDate
+  TextAreaSoftDeleteReason.Text = BuildSoftDeleteReason(oPhoto)
+  UpdateSaveButtonState()
+  
+End
+
+Private Sub BindAlbums(aAlbums As AlbumEntity[])
+  
+  Dim iRow As Integer
+  
+  TableViewAlbums.Rows.Count = 0
+  If aAlbums = Null Then
+    TableViewAlbums.Tag = New AlbumEntity[]
+    Return
+  Endif
+  
+  For Each oAlbum As AlbumEntity In aAlbums
+    iRow = TableViewAlbums.Rows.Count
+    TableViewAlbums.Rows.Count += 1
+    TableViewAlbums[iRow, 0].Text = Trim(oAlbum.Name)
+    TableViewAlbums[iRow, 1].Text = Str(oAlbum.PhotoCount)
+  Next
+  
+  TableViewAlbums.Tag = aAlbums
+  
+End
+
+Private Sub BindTags(aTags As TagEntity[])
+  
+  Dim iRow As Integer
+  
+  TableViewTags.Rows.Count = 0
+  If aTags = Null Then
+    TableViewTags.Tag = New TagEntity[]
+    Return
+  Endif
+  
+  For Each oTag As TagEntity In aTags
+    iRow = TableViewTags.Rows.Count
+    TableViewTags.Rows.Count += 1
+    TableViewTags[iRow, 0].Text = Trim(oTag.Name)
+    TableViewTags[iRow, 1].Text = Trim(oTag.Color)
+    TableViewTags[iRow, 2].Text = Str(oTag.PhotoCount)
+  Next
+  
+  TableViewTags.Tag = aTags
+  
+End
+
+Public Sub TextAreaDescription_Change()
+
+  If $IsBindingDescription Then Return
+  UpdateSaveButtonState()
+
+End
+
+Private Function ConfirmCloseIfPendingChanges() As Boolean
+  
+  If Not HasPendingChanges() Then Return True
+  
+  Return Message.Question(("There are unsaved changes. Do you want to close without saving?"), ("Close without saving"), ("Keep editing")) = 1
+  
+End
+
+Private Sub SaveChanges()
+  
+  Dim sNewDescription As String
+  Dim aCurrentAlbumIds As Integer[]
+  Dim aCurrentTagIds As Integer[]
+  Dim aPhotoIds As New Integer[]
+  Dim aAlbumIdsToAdd As Integer[]
+  Dim aAlbumIdsToRemove As Integer[]
+  Dim aTagIdsToAdd As Integer[]
+  Dim aTagIdsToRemove As Integer[]
+  
+  If $PhotoDetail = Null Then Return
+  If Not HasPendingChanges() Then Return
+  
+  sNewDescription = NormalizeDescription(TextAreaDescription.Text)
+  $PhotoDetail.Description = sNewDescription
+  
+  If Not $PhotoService.UpdatePhoto($PhotoDetail) Then
+    Message.Error(("Could not save photo description"))
+    Return
+  Endif
+  
+  aCurrentAlbumIds = ExtractAlbumIds($CurrentAlbums)
+  aCurrentTagIds = ExtractTagIds($CurrentTags)
+  aAlbumIdsToAdd = GetIdsToAdd($OriginalAlbumIds, aCurrentAlbumIds)
+  aAlbumIdsToRemove = GetIdsToRemove($OriginalAlbumIds, aCurrentAlbumIds)
+  aTagIdsToAdd = GetIdsToAdd($OriginalTagIds, aCurrentTagIds)
+  aTagIdsToRemove = GetIdsToRemove($OriginalTagIds, aCurrentTagIds)
+  
+  aPhotoIds.Add($PhotoDetail.Id)
+  
+  If aAlbumIdsToAdd.Count > 0 Then $AlbumService.AddPhotosToAlbums(aPhotoIds, aAlbumIdsToAdd)
+  If aAlbumIdsToRemove.Count > 0 Then $AlbumService.RemovePhotosFromAlbums(aPhotoIds, aAlbumIdsToRemove)
+  If aTagIdsToAdd.Count > 0 Then $TagService.AddPhotosToTags(aPhotoIds, aTagIdsToAdd)
+  If aTagIdsToRemove.Count > 0 Then $TagService.RemovePhotosFromTags(aPhotoIds, aTagIdsToRemove)
+  
+  ReloadDetails()
+  Message.Info(("Photo details updated"))
+  
+End
+
+Private Sub UpdateSaveButtonState()
+  
+  ButtonAccept.Enabled = HasPendingChanges()
+  
+End
+
+Private Function HasPendingChanges() As Boolean
+  
+  If $PhotoDetail = Null Then Return False
+  If NormalizeDescription(TextAreaDescription.Text) <> NzText($PhotoDetail.Description) Then Return True
+  If Not SameIdSet($OriginalAlbumIds, ExtractAlbumIds($CurrentAlbums)) Then Return True
+  If Not SameIdSet($OriginalTagIds, ExtractTagIds($CurrentTags)) Then Return True
+  
+  Return False
+  
+End
+
+Private Sub AddAlbumToCurrentList(oAlbum As AlbumEntity)
+  
+  If oAlbum = Null Then Return
+  If $CurrentAlbums = Null Then $CurrentAlbums = New AlbumEntity[]
+  If ContainsAlbumId($CurrentAlbums, oAlbum.Id) Then Return
+  
+  $CurrentAlbums.Add(oAlbum)
+  
+End
+
+Private Function RemoveSelectedAlbums() As Boolean
+  
+  Dim aAlbums As AlbumEntity[]
+  Dim aRemaining As New AlbumEntity[]
+  Dim iRow As Integer
+  Dim bRemoved As Boolean
+  
+  aAlbums = TableViewAlbums.Tag
+  If aAlbums = Null Then Return False
+  
+  For iRow = 0 To TableViewAlbums.Rows.Count - 1
+    If TableViewAlbums.Rows[iRow].Selected Then
+      bRemoved = True
+    Else
+      aRemaining.Add(aAlbums[iRow])
+    Endif
+  Next
+  
+  If Not bRemoved Then Return False
+  $CurrentAlbums = aRemaining
+  Return True
+  
+End
+
+Private Sub AddTagsToCurrentList(aSelectedTagIds As Integer[])
+  
+  Dim aExistingIds As Integer[]
+  Dim aAllTags As TagEntity[]
+  
+  If aSelectedTagIds = Null Then Return
+  If aSelectedTagIds.Count = 0 Then Return
+  
+  aExistingIds = ExtractTagIds($CurrentTags)
+  aAllTags = $TagService.FindTags()
+  If aAllTags = Null Then Return
+  
+  For Each oTag As TagEntity In aAllTags
+    If ContainsInteger(aSelectedTagIds, oTag.Id) And Not ContainsInteger(aExistingIds, oTag.Id) Then
+      If $CurrentTags = Null Then $CurrentTags = New TagEntity[]
+      $CurrentTags.Add(oTag)
+    Endif
+  Next
+  
+End
+
+Private Function RemoveSelectedTags() As Boolean
+  
+  Dim aTags As TagEntity[]
+  Dim aRemaining As New TagEntity[]
+  Dim iRow As Integer
+  Dim bRemoved As Boolean
+  
+  aTags = TableViewTags.Tag
+  If aTags = Null Then Return False
+  
+  For iRow = 0 To TableViewTags.Rows.Count - 1
+    If TableViewTags.Rows[iRow].Selected Then
+      bRemoved = True
+    Else
+      aRemaining.Add(aTags[iRow])
+    Endif
+  Next
+  
+  If Not bRemoved Then Return False
+  $CurrentTags = aRemaining
+  Return True
+  
+End
+
+Private Function CloneAlbums(aAlbums As AlbumEntity[]) As AlbumEntity[]
+  
+  Dim aCopy As New AlbumEntity[]
+  
+  If aAlbums = Null Then Return aCopy
+  For Each oAlbum As AlbumEntity In aAlbums
+    aCopy.Add(oAlbum)
+  Next
+  
+  Return aCopy
+  
+End
+
+Private Function CloneTags(aTags As TagEntity[]) As TagEntity[]
+  
+  Dim aCopy As New TagEntity[]
+  
+  If aTags = Null Then Return aCopy
+  For Each oTag As TagEntity In aTags
+    aCopy.Add(oTag)
+  Next
+  
+  Return aCopy
+  
+End
+
+Private Function ExtractAlbumIds(aAlbums As AlbumEntity[]) As Integer[]
+  
+  Dim aIds As New Integer[]
+  
+  If aAlbums = Null Then Return aIds
+  For Each oAlbum As AlbumEntity In aAlbums
+    aIds.Add(oAlbum.Id)
+  Next
+  
+  Return aIds
+  
+End
+
+Private Function ExtractTagIds(aTags As TagEntity[]) As Integer[]
+  
+  Dim aIds As New Integer[]
+  
+  If aTags = Null Then Return aIds
+  For Each oTag As TagEntity In aTags
+    aIds.Add(oTag.Id)
+  Next
+  
+  Return aIds
+  
+End
+
+Private Function GetIdsToAdd(aOriginalIds As Integer[], aCurrentIds As Integer[]) As Integer[]
+  
+  Dim aIds As New Integer[]
+  
+  For Each iId As Integer In aCurrentIds
+    If Not ContainsInteger(aOriginalIds, iId) Then aIds.Add(iId)
+  Next
+  
+  Return aIds
+  
+End
+
+Private Function GetIdsToRemove(aOriginalIds As Integer[], aCurrentIds As Integer[]) As Integer[]
+  
+  Dim aIds As New Integer[]
+  
+  For Each iId As Integer In aOriginalIds
+    If Not ContainsInteger(aCurrentIds, iId) Then aIds.Add(iId)
+  Next
+  
+  Return aIds
+  
+End
+
+Private Function SameIdSet(aFirstIds As Integer[], aSecondIds As Integer[]) As Boolean
+  
+  If aFirstIds.Count <> aSecondIds.Count Then Return False
+  
+  For Each iId As Integer In aFirstIds
+    If Not ContainsInteger(aSecondIds, iId) Then Return False
+  Next
+  
+  Return True
+  
+End
+
+Private Function ContainsAlbumId(aAlbums As AlbumEntity[], iAlbumId As Integer) As Boolean
+  
+  If aAlbums = Null Then Return False
+  For Each oAlbum As AlbumEntity In aAlbums
+    If oAlbum.Id = iAlbumId Then Return True
+  Next
+  
+  Return False
+  
+End
+
+Private Function ContainsInteger(aIds As Integer[], iValue As Integer) As Boolean
+  
+  If aIds = Null Then Return False
+  For Each iId As Integer In aIds
+    If iId = iValue Then Return True
+  Next
+  
+  Return False
+  
+End
+
+Private Function BuildStars(iStars As Integer) As String
+  
+  Dim iIndex As Integer
+  Dim sStars As String
+  
+  If iStars < 0 Then iStars = 0
+  If iStars > 5 Then iStars = 5
+  
+  For iIndex = 1 To 5
+    If iIndex <= iStars Then
+      sStars &= "★"
+    Else
+      sStars &= "☆"
+    Endif
+  Next
+  
+  Return sStars
+  
+End
+
+Private Function BuildSoftDeleteReason(oPhoto As PhotoEntity) As String
+  
+  If Not oPhoto.IsSoftDeleted Then Return ""
+  
+  If oPhoto.SoftDeleteDate <> Null Then
+    Return ("Moved to trash on ") & CStr(oPhoto.SoftDeleteDate)
+  Endif
+  
+  Return ("Photo currently in trash")
+  
+End
+
+Private Function NormalizeDescription(sValue As String) As String
+  
+  If sValue = Null Then Return ""
+  Return Trim(sValue)
+  
+End
+
+Private Function NzText(sValue As String) As String
+  
+  If sValue = Null Then Return ""
+  
+  Return Trim(sValue)
+  
+End
+
+Private Sub SyncOriginalPhoto(oPhoto As PhotoEntity)
+  
+  If $OriginalPhoto = Null Or oPhoto = Null Then Return
+  
+  $OriginalPhoto.FileName = oPhoto.FileName
+  $OriginalPhoto.Description = oPhoto.Description
+  $OriginalPhoto.ImportDate = oPhoto.ImportDate
+  $OriginalPhoto.ImportUser = oPhoto.ImportUser
+  $OriginalPhoto.Stars = oPhoto.Stars
+  $OriginalPhoto.IsSoftDeleted = oPhoto.IsSoftDeleted
+  $OriginalPhoto.SoftDeleteDate = oPhoto.SoftDeleteDate
+  $OriginalPhoto.SoftDeleteBy = oPhoto.SoftDeleteBy
+  $OriginalPhoto.IsLocked = oPhoto.IsLocked
+  $OriginalPhoto.LockedBy = oPhoto.LockedBy
+  $OriginalPhoto.LockedDate = oPhoto.LockedDate
+  $OriginalPhoto.LockedReason = oPhoto.LockedReason
+  
+End

--- a/.src/views/FPhotoDetails.form
+++ b/.src/views/FPhotoDetails.form
@@ -1,5 +1,191 @@
 # Gambas Form File 3.0
 
-{ FPhotoDetails Form
-  MoveScaled(0,0,64,64)
+{ Form Form
+  MoveScaled(0,0,86,108)
+  Text = ("Photo details")
+  Resizable = False
+  Arrangement = Arrange.Vertical
+  Spacing = True
+  Margin = True
+  Padding = 4
+  { VBoxContent VBox
+    MoveScaled(1,1,84,95)
+    Expand = True
+    Spacing = True
+    { LabelTitle Label
+      MoveScaled(1,1,32,4)
+      Text = ("Photo information")
+    }
+    { FrameGeneral VBox
+      MoveScaled(1,6,82,22)
+      Expand = True
+      { Label1 Label
+        MoveScaled(1,1,12,3)
+        Text = ("Name")
+      }
+      { TextBoxName TextBox
+        MoveScaled(1,4,80,4)
+        ReadOnly = True
+      }
+      { Label2 Label
+        MoveScaled(1,8,12,3)
+        Text = ("Description")
+      }
+      { TextAreaDescription TextArea
+        MoveScaled(1,11,80,8)
+      }
+      { HBoxGeneralMeta HBox
+        MoveScaled(1,19,80,4)
+        Spacing = True
+        { ValueBoxImportDate ValueBox
+          MoveScaled(1,0,21,4)
+          Type = ValueBox.DateTime
+          ReadOnly = True
+        }
+        { TextBoxImportUser TextBox
+          MoveScaled(23,0,21,4)
+          ReadOnly = True
+        }
+        { LabelStarsTitle Label
+          MoveScaled(45,0,7,4)
+          Text = ("Stars")
+        }
+        { LabelStarsValue Label
+          MoveScaled(53,0,18,4)
+          Text = ("☆☆☆☆☆")
+        }
+      }
+    }
+    { FrameStatus VBox
+      MoveScaled(1,29,82,28)
+      Expand = True
+      { HBoxLock HBox
+        MoveScaled(1,1,80,4)
+        Spacing = True
+        { SwitchButtonLock SwitchButton
+          MoveScaled(1,0,6,3)
+          Enabled = False
+        }
+        { Label3 Label
+          MoveScaled(8,0,12,3)
+          Text = ("Lock photo")
+        }
+        { TextBoxLockedBy TextBox
+          MoveScaled(22,0,18,4)
+          ReadOnly = True
+        }
+        { ValueBoxLockedDate ValueBox
+          MoveScaled(41,0,18,4)
+          Type = ValueBox.DateTime
+          ReadOnly = True
+        }
+      }
+      { TextAreaLockReason TextArea
+        MoveScaled(1,5,80,7)
+        ReadOnly = True
+      }
+      { HBoxTrash HBox
+        MoveScaled(1,13,80,4)
+        Spacing = True
+        { SwitchButtonTrash SwitchButton
+          MoveScaled(1,0,6,3)
+          Enabled = False
+        }
+        { Label6 Label
+          MoveScaled(8,0,14,3)
+          Text = ("Move to trash")
+        }
+        { TextBoxSoftDeleteBy TextBox
+          MoveScaled(24,0,18,4)
+          ReadOnly = True
+        }
+        { ValueBoxSoftDeleteDate ValueBox
+          MoveScaled(43,0,18,4)
+          Type = ValueBox.DateTime
+          ReadOnly = True
+        }
+      }
+      { TextAreaSoftDeleteReason TextArea
+        MoveScaled(1,17,80,7)
+        ReadOnly = True
+      }
+    }
+    { HBoxAssociations HBox
+      MoveScaled(1,58,82,34)
+      Expand = True
+      Spacing = True
+      { VBoxAlbums VBox
+        MoveScaled(1,1,40,32)
+        Expand = True
+        { LabelAlbums Label
+          MoveScaled(1,1,10,3)
+          Text = ("Albums")
+        }
+        { TableViewAlbums TableView
+          MoveScaled(1,4,38,20)
+          Expand = True
+          Mode = Select.Multiple
+        }
+        { HBoxAlbumButtons HBox
+          MoveScaled(1,25,38,5)
+          Spacing = True
+          { ButtonAddAlbum Button
+            MoveScaled(1,0,12,4)
+            Text = ("Add")
+          }
+          { ButtonRemoveAlbum Button
+            MoveScaled(14,0,12,4)
+            Text = ("Remove")
+          }
+        }
+      }
+      { VBoxTags VBox
+        MoveScaled(42,1,40,32)
+        Expand = True
+        { LabelTags Label
+          MoveScaled(1,1,10,3)
+          Text = ("Tags")
+        }
+        { TableViewTags TableView
+          MoveScaled(1,4,38,20)
+          Expand = True
+          Mode = Select.Multiple
+        }
+        { HBoxTagButtons HBox
+          MoveScaled(1,25,38,5)
+          Spacing = True
+          { ButtonAddTag Button
+            MoveScaled(1,0,12,4)
+            Text = ("Add")
+          }
+          { ButtonRemoveTag Button
+            MoveScaled(14,0,12,4)
+            Text = ("Remove")
+          }
+        }
+      }
+    }
+  }
+  { VBoxButtons2 VBox
+    MoveScaled(1,97,84,8)
+    { Separator2 Separator
+      MoveScaled(0,0,72,2)
+    }
+    { HBoxButtons2 HBox
+      MoveScaled(0,2,82,5)
+      Spacing = True
+      Padding = 4
+      { Spring2 Spring
+        MoveScaled(7,1,4,4)
+      }
+      { ButtonAccept Button
+        MoveScaled(15,0,18,4)
+        Text = ("Save")
+      }
+      { ButtonExit Button
+        MoveScaled(37,0,18,4)
+        Text = ("Close")
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Resumen
- agregar FPhotoDetails como formulario de detalle editable para fotos
- permitir editar glosa, administrar álbumes y tags con guardado diferido
- mostrar la glosa resumida en el tooltip de FPhoto y corregir el flujo de confirmaciones
